### PR TITLE
set default architectureType to X86_64

### DIFF
--- a/src/main/java/org/ovirt/vdsmfake/AppConfig.java
+++ b/src/main/java/org/ovirt/vdsmfake/AppConfig.java
@@ -188,7 +188,8 @@ public class AppConfig {
     }
 
     public ArchitectureType getArchitectureType() {
-        return ArchitectureType.valueOf(architectureType);
+        return architectureType != null ? ArchitectureType.valueOf(architectureType) :
+                ArchitectureType.X86_64;
     }
 
     public void setArchitectureType(String architectureType) {


### PR DESCRIPTION
In AppConfig::getArchitectureType, default to X86_64 if
an arch is not otherwise set. Fixes an NPE.